### PR TITLE
Add key release count to tests

### DIFF
--- a/tools/debounce_test/debounce_test.c
+++ b/tools/debounce_test/debounce_test.c
@@ -189,6 +189,7 @@ int main(int argc,char *argv[]) {
 
     if (print_press_count) {
         printf("%d\n",presses);
+        printf("%d\n",releases);
     }
     if (verbose) {
         printf("# Total presses: %d Total releases: %d\n",presses,releases);

--- a/tools/debounce_test/debounce_test.c
+++ b/tools/debounce_test/debounce_test.c
@@ -69,8 +69,8 @@ int main(int argc,char *argv[]) {
     if(argc ==2 && *argv[1] == 'v')  {
         verbose = 1;
     } else if(argc ==2 && *argv[1] == 'd')  { // debug - extra verbosity, show every sample transition
-	    verbose =1;
-	    extra_verbose=1;
+        verbose =1;
+        extra_verbose=1;
     } else if(argc ==2 && *argv[1] == 'i')  {
         print_input = 1;
     } else if (argc ==2 && *argv[1] =='c') {
@@ -98,57 +98,57 @@ int main(int argc,char *argv[]) {
 
     for (uint16_t sample = 0; sample < scan_counter; sample++) {
 
-	uint8_t data_printed = 0;
+        uint8_t data_printed = 0;
         debounced_changes= debounce(pin_data[sample], db);
 
         if (verbose) {
             if (comments[sample][0] != 0) {
                 printf("# %s", comments[sample]);
             }
-	}
+        }
         if (extra_verbose) {
             printf("Sample %-3d Input: %d ",sample,pin_data[sample]);
             printf("State: %d", (db[0].state ));
-	data_printed++;
+            data_printed++;
         }
-            if (pin_data[sample] != pin_data[sample-1]) {
-                if (verbose) {
-			printf(" - input changed to %d after %d cycles", pin_data[sample], sample-last_input_change);
-	data_printed++;
-		};
-                last_input_change = sample;
-            }
+        if (pin_data[sample] != pin_data[sample-1]) {
+            if (verbose) {
+                printf(" - input changed to %d after %d cycles", pin_data[sample], sample-last_input_change);
+                data_printed++;
+            };
+            last_input_change = sample;
+        }
 
 
 
         if (debounced_changes) {
-		uint16_t latency = sample - last_input_change;
-		uint16_t last_duration = sample - last_state_change;
+            uint16_t latency = sample - last_input_change;
+            uint16_t last_duration = sample - last_state_change;
             if (!(db[0].state )) {
-               
-	       
+
+
                 press_duration[presses] =last_duration;
                 release_latency_counts[releases] = latency;
-		releases++;
+                releases++;
                 if (verbose) {
                     printf(" - release %d ",releases);
-	data_printed++;
+                    data_printed++;
                 }
             } else {
-                
+
                 release_duration[releases] = last_duration;
-		presses++;
+                presses++;
                 press_latency_counts[presses] = latency;
                 if (verbose) {
                     printf(" - press %d ", presses);
-	data_printed++;
+                    data_printed++;
                 }
             }
 
             if (verbose) {
-                printf(" - state changed to %d with a latency of %d cycles (old state lasted %d cycles)", 
-				db[0].state, latency, last_duration);
-	data_printed++;
+                printf(" - state changed to %d with a latency of %d cycles (old state lasted %d cycles)",
+                       db[0].state, latency, last_duration);
+                data_printed++;
             }
 
             last_state_change = sample;
@@ -160,7 +160,7 @@ int main(int argc,char *argv[]) {
             printf("\n");
     }
 
-    release_latency_counts[0]=0; // This is a hack 
+    release_latency_counts[0]=0; // This is a hack
 
     if (verbose || print_input) {
         printf("Raw input data: (40 ms per line)\n");
@@ -222,7 +222,7 @@ int main(int argc,char *argv[]) {
 
 
 
-	printf("# Release latency:");
+        printf("# Release latency:");
         for(uint8_t i = 0; (i<=releases); i++) {
             printf(" %4d",release_latency_counts[i] );
         }
@@ -243,4 +243,3 @@ int main(int argc,char *argv[]) {
 
     exit (0);
 }
-

--- a/tools/debounce_test/run_tests.pl
+++ b/tools/debounce_test/run_tests.pl
@@ -13,10 +13,10 @@ my @testcases = `ls testcases/*/*`;
 my @debouncers = `ls ./debounce-*`;
 
 if (@ARGV) {
-@debouncers = ();
-while (@ARGV) {
-	push @debouncers, shift @ARGV;
-}
+	@debouncers = ();
+	while (@ARGV) {
+		push @debouncers, shift @ARGV;
+	}
 }
 map {chomp} @testcases;
 map { chomp} @debouncers;
@@ -30,42 +30,42 @@ my %press_counts_by_test;
 #run_debouncer('Source data', $debouncers[0], $datafile,'i');
 
 for my $test (@testcases) {
-for my $debouncer (@debouncers) {
-	next unless (-f $test);
-			next if $debouncer eq './debounce-none';
-			next if $debouncer eq './debounce-counter';
-			next if $debouncer eq './debounce-split-counters-and-lockouts';
-	next if ($test =~ /\.(raw|bak)$/);
-	my $presses = -1;
-	my $metadata = `grep  PRESSES: $test`;
-	if ($metadata =~ /PRESSES:\s*(\d*)/ ){
-		$presses = $1;
-	}
-	my $title = `grep TITLE: $test `;
-	$title =~ s/^.*?TITLE://;
-	my $sample_rate = `grep #SAMPLES-PER-SECOND: $test`;
-	if ($sample_rate =~ /SAMPLES-PER-SECOND:\s*(\d*)/) {
-		$sample_rate = $1;
-	} else {
-		$sample_rate = 625; # 1.6ms per sample
-	}
-	chomp($title);
-	my ($count,$debug) = run_debouncer ($debouncer, $test, $sample_rate, 'c');
-	
-	$press_counts_by_test{$test}{$debouncer} = $count;
-	$press_counts_by_test{$test}{'SPEC'} = $presses;
+	for my $debouncer (@debouncers) {
+		next unless (-f $test);
+		next if $debouncer eq './debounce-none';
+		next if $debouncer eq './debounce-counter';
+		next if $debouncer eq './debounce-split-counters-and-lockouts';
+		next if ($test =~ /\.(raw|bak)$/);
+		my $presses = -1;
+		my $metadata = `grep  PRESSES: $test`;
+		if ($metadata =~ /PRESSES:\s*(\d*)/ ){
+			$presses = $1;
+		}
+		my $title = `grep TITLE: $test `;
+		$title =~ s/^.*?TITLE://;
+		my $sample_rate = `grep #SAMPLES-PER-SECOND: $test`;
+		if ($sample_rate =~ /SAMPLES-PER-SECOND:\s*(\d*)/) {
+			$sample_rate = $1;
+		} else {
+			$sample_rate = 625; # 1.6ms per sample
+		}
+		chomp($title);
+		my ($count,$debug) = run_debouncer ($debouncer, $test, $sample_rate, 'c');
 
-	if ($count == $presses) {
-		$stats_by_db{$debouncer}{ok}++;
-		print "ok ". $test_num++. "     - $debouncer $test saw $presses presses\n";
-	} else {
-		$stats_by_db{$debouncer}{not_ok}++;
-		print "not ok ". $test_num++ ." - $debouncer $test saw $count presses but expected $presses\n";
-		push @{$fails_by_test{$test}},$debouncer;
-		push @{$fails_by_db{$debouncer}},$test;
+		$press_counts_by_test{$test}{$debouncer} = $count;
+		$press_counts_by_test{$test}{'SPEC'} = $presses;
+
+		if ($count == $presses) {
+			$stats_by_db{$debouncer}{ok}++;
+			print "ok ". $test_num++. "		- $debouncer $test saw $presses presses\n";
+		} else {
+			$stats_by_db{$debouncer}{not_ok}++;
+			print "not ok ". $test_num++ ." - $debouncer $test saw $count presses but expected $presses\n";
+			push @{$fails_by_test{$test}},$debouncer;
+			push @{$fails_by_db{$debouncer}},$test;
+		}
+		print $debug;
 	}
-	print $debug;
-}
 }
 
 for my $db (sort { $stats_by_db{$b}{ok} <=> $stats_by_db{$a}{ok}} keys %stats_by_db){
@@ -79,14 +79,14 @@ report_press_counts(\%press_counts_by_test);
 sub report_press_counts {
 	my $press_counts = shift;
 
-		print "Number of presses found. (Relative to the number claimed in the test file)\n";
-printf ("%60s |","Debouncer:");	
-		for my $db ( sort { length($a) <=> length ($b)} keys %{$press_counts->{'testcases/synthetic/00-simple'}}) {
-			my $display = $db;
-			$display =~ s/^\.\/debounce-//;
-			print $display." | ";
+	print "Number of presses found. (Relative to the number claimed in the test file)\n";
+	printf ("%60s |","Debouncer:");
+	for my $db ( sort { length($a) <=> length ($b)} keys %{$press_counts->{'testcases/synthetic/00-simple'}}) {
+		my $display = $db;
+		$display =~ s/^\.\/debounce-//;
+		print $display." | ";
 
-		}
+	}
 	print "\n";
 	for my $test_name  (sort { $b cmp $a } keys %$press_counts) {
 		my $all_ok =1;
@@ -107,7 +107,7 @@ printf ("%60s |","Debouncer:");
 			my $display = $db;
 			$display =~ s/^\.\/debounce-//;
 			my $output;
-			if ($db eq 'SPEC' ){ 
+			if ($db eq 'SPEC' ){
 				$output = sprintf("%".length($display)."d", $press_counts->{$test_name}{'SPEC'});
 			}
 			elsif ( $press_counts->{$test_name}{$db} != $press_counts->{$test_name}{'SPEC'}) {
@@ -138,14 +138,14 @@ sub run_debouncer {
 
 	for my $line (@samples) {
 		print CHLD_IN $line;
-	}	
+	}
 	close(CHLD_IN);
 	my $result =<CHLD_OUT>;
-			chomp($result);
+	chomp($result);
 	while (my $line =<CHLD_OUT>) {
-			$stderr .= $line;
+		$stderr .= $line;
 	}
-	
+
 	return $result, $stderr;
 }
 
@@ -162,76 +162,76 @@ sub resample {
 	my $output_ratio = shift;
 	open(FILE, '<', $file);
 
-my $output_counter = 0;
-my $input_counter  = 0;
-my $downsample_samples     = 0;
-my $downsample_accumulator = 0;
+	my $output_counter = 0;
+	my $input_counter  = 0;
+	my $downsample_samples	   = 0;
+	my $downsample_accumulator = 0;
 	my @output;
 
-while ( my $line = <FILE> ) {
-    $line =~ s/\#.*$//g;
-    $line =~ s/[^01]//g;
+	while ( my $line = <FILE> ) {
+		$line =~ s/\#.*$//g;
+		$line =~ s/[^01]//g;
 
-    for my $digit ( split( //, $line ) ) {
-        $input_counter++;
-        if ( $output_ratio > 1 ) {
-            while ( $output_counter < ( $input_counter * $output_ratio ) ) {
-                $output_counter++;
-                push @output, $digit
-                  . " # Input sample $input_counter. Output sample: "
-                  . $input_counter * $output_ratio . " - "
-                  . $output_counter . "\n";
+		for my $digit ( split( //, $line ) ) {
+			$input_counter++;
+			if ( $output_ratio > 1 ) {
+				while ( $output_counter < ( $input_counter * $output_ratio ) ) {
+					$output_counter++;
+					push @output, $digit
+						. " # Input sample $input_counter. Output sample: "
+						. $input_counter * $output_ratio . " - "
+						. $output_counter . "\n";
 
-            }
+				}
 
-        }
-        else {
+			}
+			else {
 
-            if ($downsample_averaging) {
-                $downsample_samples++;
-                $downsample_accumulator += $digit;
-                if ( ( $input_counter * $output_ratio ) >=
-                    ( $output_counter + 1 ) )
-                {
-                    $output_counter++;
-                    push @output, (
-                        ( $downsample_accumulator / $downsample_samples ) > 0.5
-                        ? '1'
-                        : '0' )
-                      . " # Input sample $input_counter. ($digit ) Output sample: "
-                      . $input_counter * $output_ratio . " - "
-                      . $output_counter . "\n";
-                    $downsample_samples     = 0;
-                    $downsample_accumulator = 0;
-                }
-                else {
-			#print STDERR "  # Input sample $input_counter Output sample " . $input_counter * $output_ratio . " DISCARDED\n";
+				if ($downsample_averaging) {
+					$downsample_samples++;
+					$downsample_accumulator += $digit;
+					if ( ( $input_counter * $output_ratio ) >=
+						 ( $output_counter + 1 ) )
+					{
+						$output_counter++;
+						push @output, (
+							( $downsample_accumulator / $downsample_samples ) > 0.5
+							? '1'
+							: '0' )
+							. " # Input sample $input_counter. ($digit ) Output sample: "
+							. $input_counter * $output_ratio . " - "
+							. $output_counter . "\n";
+						$downsample_samples		= 0;
+						$downsample_accumulator = 0;
+					}
+					else {
+						#print STDERR "	 # Input sample $input_counter Output sample " . $input_counter * $output_ratio . " DISCARDED\n";
 
-                }
+					}
 
-            }
-            else {
+				}
+				else {
 
-                if ( ( $input_counter * $output_ratio ) >
-                    ( $output_counter + 1 ) )
-                {
-                    $output_counter++;
-                    push @output, $digit
-                      . " # Input sample $input_counter. Output sample: "
-                      . $input_counter * $output_ratio . " - "
-                      . $output_counter . "\n";
-                }
-                else {
-			#print STDERR "  # Input sample $input_counter Output sample " . $input_counter * $output_ratio . " DISCARDED\n";
-                }
-            }
+					if ( ( $input_counter * $output_ratio ) >
+						 ( $output_counter + 1 ) )
+					{
+						$output_counter++;
+						push @output, $digit
+							. " # Input sample $input_counter. Output sample: "
+							. $input_counter * $output_ratio . " - "
+							. $output_counter . "\n";
+					}
+					else {
+						#print STDERR "	 # Input sample $input_counter Output sample " . $input_counter * $output_ratio . " DISCARDED\n";
+					}
+				}
 
-        }
+			}
 
-    }
+		}
 
-}
+	}
 
-close(FILE);
-return @output;
+	close(FILE);
+	return @output;
 };


### PR DESCRIPTION
Test now reports and compare release count to catch "sticky" keys.
(Also couldn't help myself to fix whitespaces and indentation)

I followed your new debouncer and tests changes, and looking at `integrator`, I though the "locked out" feature might stick keys in the press position, so I added a release count to the test, and padded the test-cases with 200 '0's in `run_tests.pl` so the debouncers should have time to release the key.

Now, `integrator` and `state-machine` fail more tests (sorry about that).

Before:
```
./debounce-state-machine                : OK 301  FAIL 1   
./debounce-state-machine                : Failed: testcases/impossible-chatter/key-i-1--1-presses-slow.data
./debounce-split-counters               : OK 297  FAIL 5   
./debounce-split-counters               : Failed: testcases/bad-manual-samples/13-key-o-1-press, testcases/impossible-chatter/key-i-1--1-presses-slow.data, testcases/jays-attiny-detect-logic-i/key-i-2----5-presses-slow.data, testcases/jays-attiny-detect-logic/key-i-3--5-presses-slow.data, testcases/jay-s/key-i--9-presses-slow.data
./debounce-integrator                   : OK 296  FAIL 6   
./debounce-integrator                   : Failed: testcases/bad-manual-samples/13-chattering-o-2-more-presses, testcases/bad-manual-samples/13-key-o-1-press, testcases/impossible-chatter/key-i-1--1-presses-slow.data, testcases/jays-attiny-detect-logic-i/key-i-2----5-presses-slow.data, testcases/jays-attiny-detect-logic/key-i-3--5-presses-slow.data, testcases/jay-s/key-i--9-presses-slow.data
```
After, with release count test:
```
./debounce-split-counters               : OK 297  FAIL 5   
./debounce-split-counters               : Failed: testcases/bad-manual-samples/13-key-o-1-press, testcases/impossible-chatter/key-i-1--1-presses-slow.data, testcases/jays-attiny-detect-logic-i/key-i-2----5-presses-slow.data, testcases/jays-attiny-detect-logic/key-i-3--5-presses-slow.data, testcases/jay-s/key-i--9-presses-slow.data
./debounce-integrator                   : OK 296  FAIL 6   
./debounce-integrator                   : Failed: testcases/bad-manual-samples/13-chattering-o-2-more-presses, testcases/bad-manual-samples/13-key-o-1-press, testcases/impossible-chatter/key-i-1--1-presses-slow.data, testcases/jays-attiny-detect-logic-i/key-i-2----5-presses-slow.data, testcases/jays-attiny-detect-logic/key-i-3--5-presses-slow.data, testcases/jay-s/key-i--9-presses-slow.data
./debounce-state-machine                : OK 293  FAIL 9   
./debounce-state-machine                : Failed: testcases/bad-manual-samples/07-chatty-i-1, testcases/bad-manual-samples/07-chatty-i-2, testcases/bad-manual-samples/07-chatty-i-4, testcases/bad-manual-samples/07-chatty-i-5, testcases/bad-manual-samples/08-chatty-k-1, testcases/bad-manual-samples/09-chatty-p-2, testcases/bad-manual-samples/13-chattering-o-3-presses, testcases/impossible-chatter/key-i-1--1-presses-slow.data, testcases/synthetic/01-short-press
```

