### PR TITLE
Fix flasher flashing non-stop

### DIFF
--- a/etc/flash_firmware.ino
+++ b/etc/flash_firmware.ino
@@ -273,12 +273,11 @@ byte update_attiny(byte addr) {
     return 1;
 }
 
+int left_written = 0;
+int right_written = 0;
+
 void loop() {
     delay(5000);
-
-    int left_written = 0;
-    int right_written = 0;
-
 
     if (left_written > 0) {
         debug_msg(F("Done with left side.\n"));


### PR DESCRIPTION
Since 1b4bb86c98 the flasher continues re-flashing in loops instead of printing `It is now safe to reflash your keyboard with regular firmware` when it successfully flashed both sides once.

This PR should fix this.

