### PR TITLE
Clean flasher debug output and reduce delays

### DIFF
--- a/etc/flash_firmware.ino
+++ b/etc/flash_firmware.ino
@@ -15,28 +15,17 @@ extern "C" {
 #define ENDTRANS_DATA_NACK 3
 #define ENDTRANS_ERROR 4
 
-#define debug_printf(__fmt, ...)   fprintf_P(&g_serial_stream, PSTR(__fmt), ##__VA_ARGS__)
-#define debug_result(__res)        fprintf_P(&g_serial_stream, PSTR("(res=%d)"), (__res))
-#define debug_resultln(__res)      fprintf_P(&g_serial_stream, PSTR("(res=%d)\n"), (__res))
+#define debug_print(...) Serial.print(__VA_ARGS__)
 
-FILE    g_serial_stream;
+void    debug_resultln(uint8_t res)
+{
+    debug_print("(res=");
+    debug_print(res, DEC);
+    debug_print(")\n");
+}
 
 void setup() {
-
-    // setup g_serial_stream to output in Serial
-    fdev_setup_stream(
-        &g_serial_stream,
-        [](char c, FILE *f) {
-            Serial.write(c);
-            return 1;
-        },
-        nullptr,
-        _FDEV_SETUP_WRITE
-    );
-
-    debug_printf("Setup\n");
     delay(2000);
-    debug_printf("Init twi\n");
     twi_init();
 }
 
@@ -76,7 +65,7 @@ uint8_t read_crc16(byte addr, byte *version, uint16_t *crc16, uint16_t offset, u
     uint8_t result = ENDTRANS_ADDR_NACK;
 
 
-// get version and CRC16 // addr (lo) // addr (hi) // len (lo) // len (hi)
+    // get version and CRC16 // addr (lo) // addr (hi) // len (lo) // len (hi)
     uint8_t data[] = { (0x06), (uint8_t)(offset & 0xff), (uint8_t)(offset >> 8), (uint8_t)(length & 0xff), (uint8_t)(length >> 8) };
     result = twi_writeTo(addr, data, ELEMENTS(data), true, true);
 
@@ -107,7 +96,7 @@ void get_version (byte addr) {
 
     byte result = ENDTRANS_ADDR_NACK;
     while (result != ENDTRANS_SUCCESS) {
-        debug_printf("Reading CRC16 ");
+        debug_print("Reading CRC16 ");
         byte version;
         uint16_t crc16;
         result = read_crc16(addr, &version, &crc16, 0, firmware_length);
@@ -116,8 +105,11 @@ void get_version (byte addr) {
             _delay_ms(100);
             continue;
         }
-        debug_printf("Version: %d\n", version);
-        debug_printf("Existing CRC16 of 0000-1FFF: %#x\n", crc16);
+        debug_print("Version:");
+        debug_print(version);
+        debug_print("\nExisting CRC16 of 0000-1FFF: ");
+        debug_print(crc16, HEX);
+        debug_print("\n");
     }
 
 }
@@ -125,15 +117,15 @@ void get_version (byte addr) {
 
 
 int erase_program(uint8_t addr) {
-// erase user space
+    // erase user space
     uint8_t data[] = { 0x04 };
     uint8_t result = twi_writeTo(addr, data, ELEMENTS(data), true, true);
 
-    debug_printf("Erasing ");
+    debug_print("Erasing ");
     debug_resultln(result);
     if (result != ENDTRANS_SUCCESS) {
         _delay_ms(1000);
-        debug_printf("failed.\n");
+        debug_print("Failed.\n");
         return -1;
     }
     return 0;
@@ -147,17 +139,19 @@ int write_firmware(uint8_t addr ) {
     uint8_t o = 0;
 
     for (uint16_t i = 0; i < firmware_length; i += page_size) {
-        debug_printf("Page %d, setting address ", offsets[o]);
+        debug_print("Page ");
+        debug_print(offsets[o]);
+        debug_print(", setting address res=");
 
         // write page addr
         uint8_t data[] = { 0x01, (uint8_t)(offsets[o] & 0xff), (uint8_t)(offsets[o] >> 8)};
         result = twi_writeTo(addr, data, ELEMENTS(data), true, true);
-        debug_result(result);
+        debug_print(result);
 
         _delay_ms(DELAY);
         // got something other than ACK. Start over.
         if (result != ENDTRANS_SUCCESS) {
-            debug_printf(" Error\n");
+            debug_print("\nFailed.\n");
             return -1;
         }
 
@@ -184,16 +178,19 @@ int write_firmware(uint8_t addr ) {
             data[data_counter++] = (0x00); // dummy end uint8_t
 
             result = twi_writeTo(addr, data, ELEMENTS(data), true, true);
-            debug_printf(" Frame %d ", frame);
-            debug_result(result);
+            debug_print(", Frame ");
+            debug_print(frame);
+            debug_print(" res=");
+            debug_print(result);
+
             // got something other than NACK. Start over.
             if (result != ENDTRANS_DATA_NACK) {
-                debug_printf("ERROR: Got something other than NACK\n");
+                debug_print("\nERROR: Got something other than NACK\n");
                 return -1;
             }
             delay(DELAY);
         }
-        debug_printf("\n");
+        debug_print("\n");
         o++;
     }
     return 0;
@@ -203,9 +200,9 @@ int write_firmware(uint8_t addr ) {
 int verify_firmware(byte addr) {
     byte result = ENDTRANS_DATA_NACK;
     // verify firmware
-    debug_printf("Verifying install\n");
+    debug_print("Verifying install\n");
     while (result != ENDTRANS_SUCCESS) {
-        debug_printf("CRC16 ");
+        debug_print("CRC16 ");
 
         byte version;
         uint16_t crc16;
@@ -218,8 +215,16 @@ int verify_firmware(byte addr) {
             _delay_ms(100);
             continue;
         }
-        debug_printf("Version: %d\n", version);
-        debug_printf("CRC CRC16 of %#06x-%#06x: %#x\n", offsets[0] + 4, offsets[0] + firmware_length, crc16);
+
+        debug_print("Version: ");
+        debug_print(version);
+        debug_print("\nCRC CRC16 of ");
+        debug_print(offsets[0] + 4, HEX);
+        debug_print("-");
+        debug_print(offsets[0] + firmware_length, HEX);
+        debug_print(": ");
+        debug_print(crc16, HEX);
+        debug_print("\n");
 
         // calculate our own CRC16
         uint16_t check_crc16 = 0xffff;
@@ -227,16 +232,18 @@ int verify_firmware(byte addr) {
             check_crc16 = _crc16_update(check_crc16, pgm_read_byte(&firmware[i]));
         }
         if (crc16 != check_crc16) {
-            debug_printf("CRC CRC16 fail: %#x\n", check_crc16);
+            debug_print("CRC CRC16 fail: ");
+            debug_print(check_crc16);
+            debug_print("\n");
             return -1;
         }
-        debug_printf("OK\n");
+        debug_print("OK\n");
     }
     return 0;
 }
 
 byte update_attiny(byte addr) {
-    debug_printf("Communicating\n");
+    debug_print("Communicating\n");
 
     get_version(addr);
 
@@ -249,19 +256,19 @@ byte update_attiny(byte addr) {
 
     int firmware_written = write_firmware(addr);
     if(firmware_written == -1) {
-        debug_printf("Failed write.\n");
+        debug_print("Write failed.\n");
         return 0;
     }
 
     int firmware_verified = verify_firmware(addr);
     if(firmware_verified == -1) {
-        debug_printf("Failed verify.\n");
+        debug_print("Verify failed.\n");
         return 0;
     }
 
-    debug_printf("Resetting ");
+    debug_print("Resetting ");
     run_command(addr, 0x03); // execute app
-    debug_printf("Done!\n");
+    debug_print("Done!\n");
 
     return 1;
 }
@@ -273,30 +280,28 @@ void loop() {
     delay(2000);
 
     if (left_written > 0) {
-        debug_printf("Done with left side.\n");
+        debug_print("Done with left side.\n");
         // we're done
     } else {
-        debug_printf("Updating left side\n");
+        debug_print("Updating left side\n");
         reset_left_attiny();
         left_written = update_attiny(LEFT_ADDRESS);
 
     }
 
     if (right_written > 0) {
-        debug_printf("Done with right side.\n");
+        debug_print("Done with right side.\n");
         // we're done
     } else {
-        debug_printf("Updating right side\n");
+        debug_print("Updating right side\n");
         reset_right_attiny();
         right_written = update_attiny(RIGHT_ADDRESS);
     }
 
     if (left_written && right_written  ) {
-        debug_printf("Both ATTiny MCUs have been flashed\nIt is now safe to reload the regular firmware\n");
+        debug_print("Both ATTiny MCUs have been flashed\nIt is now safe to reload the regular firmware\n");
         return;
     }
 
 
 }
-
-

--- a/etc/flash_firmware.ino
+++ b/etc/flash_firmware.ino
@@ -35,7 +35,7 @@ void setup() {
     );
 
     debug_printf("Setup\n");
-    delay(5000);
+    delay(2000);
     debug_printf("Init twi\n");
     twi_init();
 }
@@ -270,7 +270,7 @@ int left_written = 0;
 int right_written = 0;
 
 void loop() {
-    delay(5000);
+    delay(2000);
 
     if (left_written > 0) {
         debug_printf("Done with left side.\n");


### PR DESCRIPTION
At first I tried to fix the few `\n` that changed since the flasher debug output refactor, but I ended up replacing `debug_msg` and `print_result` by a new `debug_printf` and `debug_result`.

The changes in the output are minor (a `\n` removed, one added, a few words changed/added ...), so I let you decide if the code changes are worth it.

On top of that commit I also did a separate one to reduce the setup and loop delay from 5 seconds to 2 seconds. So, it now delays only 4 seconds before flashing (instead of 10 seconds), seems more reasonable, especially because I flash with `make -B flash && sleep 2 && stty -F /dev/ttyACM0 9600 cs8 && cat /dev/ttyACM0`.

I did a dozen of flashes with this code while working on keyscanner without any issue.
