### PR TITLE
Keyscan miss keyscan interval with debounce-state-machine

### DIFF
--- a/firmware/keyscanner.c
+++ b/firmware/keyscanner.c
@@ -68,6 +68,7 @@ void keyscanner_main(void) {
         uint8_t     k = key_led_map[row][col];
         uint8_t     *bgr = led_get_one_addr_unsafe(k);
         bgr[2] = 255;
+        led_data_ready();
     }
 #endif
 

--- a/firmware/keyscanner.c
+++ b/firmware/keyscanner.c
@@ -46,13 +46,11 @@ void keyscanner_main(void) {
     do_scan_counter = 0;
 
     // DEBUG performance alert
-    // lits a key led if keyscanner_main missed a scan
-    // (probably due to something taking too long)
-    // (will interfere with any other LED animation running)
+    // Lits up the red component of a key if keyscanner_main missed a scan.
+    // Stays red until something else updates the led color.
 //#define DEBUG_PERFORMANCE_ALERT_WITH_LED
 
 #ifdef DEBUG_PERFORMANCE_ALERT_WITH_LED
-    // adds ~20 instructions (avr-objdump -d main.elf | wc -l)
     if (last_scan_counter > 1)
     {
         // @FIXME: this is the left-hand, right-hand key_led_map is slightly different
@@ -62,22 +60,14 @@ void keyscanner_main(void) {
             {1, 6, 9, 14, 17, 22, 24, 29},
             {0, 7, 8, 15, 16, 23, 31, 30},
         };
-
         uint8_t     row = 1;
         uint8_t     col = 1;
-
+        // Adds only ~4 instructions (avr-objdump -d main.elf | wc -l).
+        // But much more code than can actually significantly bias performance
+        // measurement
         uint8_t     k = key_led_map[row][col];
         uint8_t     *bgr = led_get_one_addr_unsafe(k);
-
-        bgr[0] = 0;
-        bgr[1] = 0;
-        bgr[2] = 0;
-        if (last_scan_counter == 2)
-            bgr[0] = 255; // blue
-        else if (last_scan_counter == 3)
-            bgr[1] = 255; // green
-        else
-            bgr[2] = 255; // red
+        bgr[2] = 255;
     }
 #endif
 

--- a/firmware/keyscanner.c
+++ b/firmware/keyscanner.c
@@ -9,8 +9,8 @@
 
 debounce_t db[COUNT_OUTPUT];
 
-// do_scan gets set any time we should actually do a scan
-volatile uint8_t do_scan = 1;
+// do_scan_counter gets set any time we should actually do a scan
+static volatile uint8_t do_scan_counter = 1;
 
 
 void keyscanner_set_interval(uint8_t interval) {
@@ -37,11 +37,11 @@ void keyscanner_main(void) {
     uint8_t debounced_changes = 0;
     uint8_t pin_data;
 
-    if (__builtin_expect(do_scan == 0, EXPECT_TRUE)) {
+    uint8_t last_scan_counter = do_scan_counter;
+    if (__builtin_expect(last_scan_counter == 0, EXPECT_TRUE)) {
         return;
     }
-
-    do_scan = 0;
+    do_scan_counter = 0;
 
     // For each enabled row...
     for (uint8_t output_pin = 0; output_pin < COUNT_OUTPUT; ++output_pin) {
@@ -126,7 +126,7 @@ void keyscanner_timer1_init(void) {
     sei();
 }
 
-// interrupt service routine (ISR) for timer 1 A compare match
+// interrupt service routine (ISR) for timer 1 channel A compare match
 ISR(TIMER1_COMPA_vect) {
-    do_scan = 1; // Yes! Let's do a scan
+    ++do_scan_counter; // Yes! Let's do a scan
 }

--- a/firmware/led-spiout.c
+++ b/firmware/led-spiout.c
@@ -110,6 +110,10 @@ void led_set_one_to(uint8_t led, uint8_t *buf) {
 
 }
 
+uint8_t *led_get_one_addr_unsafe(uint8_t led) {
+    return (uint8_t *)led_buffer.each[led];
+}
+
 void led_set_global_brightness(uint8_t brightness) {
     // Legal brightness inputs are 0 to 31.
     // But the output we want has the 3 high bytes set anyway

--- a/firmware/led-spiout.h
+++ b/firmware/led-spiout.h
@@ -31,6 +31,9 @@ void led_update_all(uint8_t *buf);
 /* Call this when you want to set only a single LED */
 void led_set_one_to(uint8_t led, uint8_t * led_data);
 
+/* For debugging only, call this when you want to get only a single LED */
+uint8_t *led_get_one_addr_unsafe(uint8_t led);
+
 /* Call this when you want to set every LED to the same value */
 void led_set_all_to(uint8_t * led_data);
 

--- a/firmware/led-spiout.h
+++ b/firmware/led-spiout.h
@@ -12,6 +12,7 @@
 
 
 
+void led_data_ready();
 
 /* Call to begin transmitting LED data */
 void led_init(void);


### PR DESCRIPTION
(I not expecting this to be merged, I'm putting this here for convenience)

The code I pushed here is a crude debugging code that lits up a key LED when the keyscan is missed. The `Q` and `any` key lits up blue if keyscan is missed once, green if missed twice, and red if missed 3 times or more (and in-between when flickering).

I did it to profile my tests, but then tested it with **`debounce-state-machines/chatter-defense` and it seems to miss a keyscan. It means excepted delays could actually be 2 times higher**, and `debounce_test` might be farther than what's happening in reality.
It would require either to optimize the code, or to increase `KEYSCAN_INTERVAL_DEFAULT` and change all the delays.

PS: any led animation (boot breath) interfere with the led. But you don't actually need to re-flash Model01-Firmware after flashing_tool flash to see/test this.

PS: The debug code adds 20 instructions, should be negligible. But I also caught the miss with simpler debug code that detected the miss by just masking out the sample pin value to disable the keys.

EDIT: look for `DEBUG_PERFORMACE_ALERT_WITH_LED` in `keyscanner.c` to enable the debug led.
