### PR TITLE
led spiout improvements

### DIFF
--- a/firmware/led-spiout.c
+++ b/firmware/led-spiout.c
@@ -185,6 +185,34 @@ void led_set_spi_frequency(uint8_t frequency) {
     }
 }
 
+/* Sets all leds off, without using the interrupt */
+static void _led_all_off_no_interrupt() {
+    /* make sure we disabled the interrupt ! */
+    DISABLE_LED_WRITES;
+
+#define WAIT_SPI_TRANSMIT()     do { while (!(SPSR & _BV(SPIF))) ; } while (0)
+    SPDR = 0;
+    for (uint8_t i = 0; i < LED_START_FRAME_BYTES - 1; ++i) {
+        WAIT_SPI_TRANSMIT();
+        SPDR = 0;
+    }
+    for (uint8_t i = 0; i < NUM_LEDS; ++i) {
+        WAIT_SPI_TRANSMIT();
+        SPDR = BRIGHTNESS_MASK | 0;
+        WAIT_SPI_TRANSMIT();
+        SPDR = 0;
+        WAIT_SPI_TRANSMIT();
+        SPDR = 0;
+        WAIT_SPI_TRANSMIT();
+        SPDR = 0;
+    }
+    for (uint8_t i = 0; i < LED_END_FRAME_BYTES; ++i) {
+        WAIT_SPI_TRANSMIT();
+        SPDR = 0;
+    }
+    WAIT_SPI_TRANSMIT();
+#undef WAIT_SPI_TRANSMIT
+}
 
 void led_init() {
 
@@ -192,7 +220,18 @@ void led_init() {
     DDRB = _BV(5)|_BV(3)|_BV(2);
     PORTB &= ~(_BV(5)|_BV(3)|_BV(2));
 
-    led_set_spi_frequency(led_spi_frequency);
+    /* Set all leds off as fast as possible.
+     *
+     * We don't use the SPI transfer interrupt here so we can synchronously turn
+     * off all leds now, then synchronously change SPI frequency without
+     * interference.
+     */
+    led_set_spi_frequency(LED_SPI_FREQUENCY_AT_INIT);
+    _led_all_off_no_interrupt();
+
+    /* Set the default led SPI frequency */
+    if (led_spi_frequency != LED_SPI_FREQUENCY_DEFAULT)
+        led_set_spi_frequency(LED_SPI_FREQUENCY_DEFAULT);
 
     /* Trigger a first transmission */
     leds_dirty = 1;
@@ -200,7 +239,7 @@ void led_init() {
     // Launch the very first transfer so SPI_STC_vect is called after that
     // (We could also manually set SPIF)
     // (An additional 8 zero bits start frame should not matter)
-    SPDR = 0x00;
+    // SPDR = 0x00; // ! BUT don't do that since _led_all_off_no_interrupt() does it
 }
 
 typedef enum {

--- a/firmware/led-spiout.c
+++ b/firmware/led-spiout.c
@@ -21,8 +21,12 @@
  * shouldn't matter.
  */
 
+#define BRIGHTNESS_MASK 0b11100000
 
-uint8_t led_spi_frequency = LED_SPI_FREQUENCY_DEFAULT;
+#define ENABLE_LED_WRITES SPCR |= _BV(SPIE);
+#define DISABLE_LED_WRITES SPCR &= ~_BV(SPIE);
+
+static uint8_t led_spi_frequency = LED_SPI_FREQUENCY_DEFAULT;
 
 typedef union {
     uint8_t each[NUM_LEDS][LED_DATA_SIZE];
@@ -38,12 +42,7 @@ static volatile enum {
     END_FRAME
 } led_phase;
 
-#define BRIGHTNESS_MASK	0b11100000
-
-#define ENABLE_LED_WRITES SPCR |= _BV(SPIE);
-#define DISABLE_LED_WRITES   SPCR &= ~_BV(SPIE);
-
-static volatile uint8_t global_brightness = 0xFF;
+static volatile uint8_t global_brightness = BRIGHTNESS_MASK | 31; /* max is 31 */
 
 static volatile uint8_t index; /* next byte to transmit */
 static volatile uint8_t subpixel = 0;
@@ -135,9 +134,10 @@ void led_set_all_off (void) {
     led_data_ready();
 }
 
-inline uint8_t led_get_spi_frequency() {
+uint8_t led_get_spi_frequency() {
     return led_spi_frequency;
 }
+
 void led_set_spi_frequency(uint8_t frequency) {
     led_spi_frequency = frequency;
 

--- a/firmware/led-spiout.c
+++ b/firmware/led-spiout.c
@@ -52,7 +52,8 @@ typedef union {
     uint8_t bank[NUM_LED_BANKS][LED_BANK_SIZE];
 } led_buffer_t;
 
-static volatile led_buffer_t led_buffer;
+/* (No volatile because all writes are outside the interrupt and in PROTECT_LED_WRITES) */
+static led_buffer_t led_buffer;
 
 static volatile enum {
     START_FRAME,
@@ -60,7 +61,7 @@ static volatile enum {
     END_FRAME
 } led_phase;
 
-static volatile uint8_t global_brightness = BRIGHTNESS_MASK | 31; /* max is 31 */
+static uint8_t global_brightness = BRIGHTNESS_MASK | 31; /* max is 31 */
 
 static volatile uint8_t index; /* next byte to transmit */
 static volatile uint8_t subpixel = 0;

--- a/firmware/led-spiout.h
+++ b/firmware/led-spiout.h
@@ -11,15 +11,13 @@
 #define LED_BANK_SIZE (LED_DATA_SIZE*NUM_LEDS_PER_BANK)
 
 
-
-
 /* Call to begin transmitting LED data */
 void led_init(void);
 
 /* Call to change the speed at which we update the LEDs */
 void led_set_spi_frequency(uint8_t frequency);
 
-uint8_t  led_get_spi_frequency(void);
+uint8_t led_get_spi_frequency(void);
 
 /* Call this when you have new preformatted data for one bank of the LEDs */
 void led_update_bank(uint8_t *buf, const uint8_t bank);

--- a/firmware/wire-protocol-constants.h
+++ b/firmware/wire-protocol-constants.h
@@ -22,7 +22,10 @@
 
 // 512KHZ seems to be the sweet spot in early testing
 // so make it the default
-#define LED_SPI_FREQUENCY_DEFAULT LED_SPI_FREQUENCY_1MHZ
+#define LED_SPI_FREQUENCY_DEFAULT LED_SPI_FREQUENCY_512KHZ
+
+// Only for fast led_init, then set to LED_SPI_FREQUENCY_DEFAULT
+#define LED_SPI_FREQUENCY_AT_INIT LED_SPI_FREQUENCY_1MHZ
 
 
 #define TWI_CMD_LED_UPDATE_ALL 0x79

--- a/firmware/wire-protocol.h
+++ b/firmware/wire-protocol.h
@@ -8,10 +8,6 @@
 #define DEVICE_VERSION 3
 
 
-
-
-extern uint8_t led_spi_frequency;
-
 // Default about 0.47ms between reads.
 // This lets us do two scans per ms, which -might- let us send updates every ms.
 #define KEYSCAN_INTERVAL_DEFAULT 14


### PR DESCRIPTION
I think I improved `led-spiout` a bit trying get more time to run the debouncer.

Here are the changes I made:

- Misc optimizations: `SPI_STC_vect`'s switch, remove redundancies, removed some unneeded `volatile` to help the compiler, simplify `leds_dirty` (no data race). I measured(*) a gain of the time of less than half a keyscan at 14 interval, and 1MHz LED SPI.

- Reduced SPI frequency back to 512kHz, but kept 1MHz just at startup for the first 'all led off'. **This is what helped most**: I measured(*) `chatter-defense` now never miss more than 2 keyscans while rainbow wave is running. (If the 1MHz (1aa3c74ee8) wasn't only to reduce power-up led flashing, then my change is wrong)

- Reduced _some_ of the led flickering/flashing at power-up: I think some of the flickering was due to a bug in `led_init()`, caught a "second flashing" by adding delays in between init steps: it seemed to launched SPI transfer before initializing spi/port/variables (?), so I clarified the code (init global var at declaration, remove redundancies...).

- Maybe reduced _some_ more flickering with `led_all_off_no_interrupt` hard-coded without using the interrupt so it should be faster (also helps to safely change back the spi freq at startup).

- Changed `DISABLE_INTERRUPTS` to custom `PROTECT_LED_WRITES` that only disables the LED SPI interrupt, because all the led update functions are called inside interrupts (`TWI_Rx_Data_Callback` is called from the TWI interrupt), and `DISABLE_INTERRUPTS` re-enables the global interrupt flag, which, I think, is bad and could cause interrupt recursion !?

It does not seem to change the size of the flasher Sketch or Global variable (weird because in total there is fewer instructions).

(*): I benchmarked by using a [new debug miss keyscann with leds](https://github.com/Gravemind/avr_keyscanner/commit/led-spiout-work-debug), less overhead but still non-zero, and the code changes a bit when applied on this branch of f/configurable-scanners-and-debouncers ...

