### PR TITLE
insert NOPs to work around Model 01 bootloader

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -35,7 +35,7 @@ CLOCK      ?= 8000000
 # PROGRAMMER = -c dragon_isp -P usb
 
 # Add more objects for each .c file here
-OBJECTS    = main.o twi-slave.o ringbuf.o wire-protocol.o keyscanner.o led-apa102c.o led-issi31fl3743b.o led-ws2812b.o led-null.o
+OBJECTS    = main.o twi-slave.o ringbuf.o wire-protocol.o keyscanner.o led-apa102c.o led-issi31fl3743b.o led-ws2812b.o led-null.o nops.o
 
 
 # Output files

--- a/firmware/config/keyboardio-model-01.h
+++ b/firmware/config/keyboardio-model-01.h
@@ -63,3 +63,7 @@
 
 // AD01: lower two bits of device address
 #define AD01() ((PINB & _BV(0)) |( PINB & _BV(1)))
+
+#if __GNUC__ > 5
+#define EMIT_NOPS
+#endif

--- a/firmware/nops.S
+++ b/firmware/nops.S
@@ -1,0 +1,5 @@
+/* Emit some NOPs to .ctors to work around a bootloader issue on Model 01 */
+#ifdef EMIT_NOPS
+	.section .ctors
+	.skip 16
+#endif


### PR DESCRIPTION
Insert some NOPs so that the Model 01 ATtiny bootloader will
jump to a correct address when starting the application.

The GCC 5- used to build the original ATtiny keyscan firmware
apparently started the application code at 0x38 instead of 0x28.
Newer GCC starts the application code at 0x28, so building the
keyscan firmware on newer GCC means the bootloader jumps into
the middle of some of the AVR CRT initialization, making things
break horribly.

Work around this by inserting some NOPs into .ctors so that the
actual application code starts at 0x38 on Model 01.