### PR TITLE
use intelhex library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ PROGRAMMER ?= -c usbtiny
 
 AVRDUDE = $(AVRDUDE_PATH) $(PROGRAMMER) -p $(DEVICE) -v
 
+PYTHON = python3
+
 flash:	all
 	$(AVRDUDE) -B 2 -U flash:w:out/$(OUTPUT_DIR)/$(DEVICE)_factory.hex:i
 
@@ -63,7 +65,7 @@ flashing-tool: build
 	mkdir -p out/$(OUTPUT_DIR)/$(DEVICE)_flasher
 	cp etc/flasher_Makefile out/$(OUTPUT_DIR)/$(DEVICE)_flasher/Makefile
 	cp etc/flash_firmware.ino out/$(OUTPUT_DIR)/$(DEVICE)_flasher/$(DEVICE)_flasher.ino
-	python2.7 ./tools/hex_to_atmega.py out/$(OUTPUT_DIR)/$(DEVICE)_keyscanner.hex > out/$(OUTPUT_DIR)/$(DEVICE)_flasher/$(DEVICE)_flasher.h
+	$(PYTHON) ./tools/hex_to_atmega.py out/$(OUTPUT_DIR)/$(DEVICE)_keyscanner.hex > out/$(OUTPUT_DIR)/$(DEVICE)_flasher/$(DEVICE)_flasher.h
 	mkdir -p out/dist
 	cd out && tar czf dist/$(DEVICE)_firmware-`git describe`.tar.gz $(OUTPUT_DIR)
 

--- a/tools/hex_to_atmega.py
+++ b/tools/hex_to_atmega.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 
-from collections import namedtuple
+from intelhex import IntelHex
 import sys
 
 page_size = 64
@@ -11,55 +11,30 @@ delay_ms = 1
 
 template = open('etc/flash_firmware_h.template', 'r').read()
 
-Line = namedtuple('Line', ['size', 'offset', 'kind', 'data', 'checksum'])
+ih = IntelHex(sys.argv[1])
 
-def parse_line(line):
-    """Parses an Intel HEX line into a Line tuple"""
-    if len(line) < 11:
-        exit("invalid Intel HEX line: %s" % line)
-    if line[0] != ':':
-        exit("invalid Intel HEX line: %s" % line)
-    line = line[1:]
-    try:
-        int(line, 16)
-    except ValueError:
-        exit("invalid Intel HEX line: %s" % line)
-    line = line.decode('hex')
-    return Line(line[0], line[1:3], line[3], line[4:-1], line[-1])
-
-with open(sys.argv[1]) as fin:
-    hex_in = fin.read()
-
-hex_lines = [parse_line(l) for l in hex_in.strip().split()]
-hex_lines = [l for l in hex_lines if l.kind == '\x00']
-
-mem = [blank] * memory_size
+data = bytearray()
 offsets = []
-data = []
-for line in hex_lines:
-    offset = (ord(line.offset[0]) << 8) + ord(line.offset[1])
-    for i, x in enumerate(line.data):
-        mem[offset + i] = ord(x)
+for i in range(ih.minaddr(), ih.maxaddr(), page_size):
+    # Accumulate data bytes in page_size chunks, but only for addresses
+    # that are present in contiguous segments.
+    for (start, stop) in ih.segments():
+        if i not in range(start, stop):
+            continue
+        offsets.append(i)
+        # IntelHex will automatically fill missing bytes with 0xFF
+        data += ih.tobinarray(start=i, size=page_size)
 
-# # if the first offset is not 0, then we need to write an additional 4 bytes for some reason
-# for i in xrange(0, len(mem)):
-#     if mem[i] != 0:
-#         if i >= 4:
-#             mem[i-4] = blank
-#             mem[i-3] = blank
-#             mem[i-2] = blank
-#             mem[i-1] = blank
-#         break
-#
-# scan memory
-for i in xrange(0, len(mem), page_size):
-    # can skip this page
-    if all(x == blank for x in mem[i:i+page_size]):
-        continue
-    offsets.append(i)
-    data.extend(mem[i:i+page_size])
+# Write page offsets, 8 per line
+offsets_text = '\n'
+for i in range(0, len(offsets), 8):
+    line = ", ".join("0x%04x" % x for x in offsets[i:i+8])
+    offsets_text += "    %s,\n" % line
 
-offsets_text = ', '.join(str(x) for x in offsets)
-data_text = ', '.join(hex(x) for x in data)
+# Write byte values, 8 per line
+data_text = '\n'
+for i in range(0, len(data), 8):
+    line = ", ".join("0x%02x" %x for x in data[i:i+8])
+    data_text += "    %s,\n" % line
 
-print template % (page_size, frame_size, blank, len(offsets), len(data), delay_ms, offsets_text, data_text)
+print(template % (page_size, frame_size, blank, len(offsets), len(data), delay_ms, offsets_text, data_text))

--- a/tools/make_factory_firmware.py
+++ b/tools/make_factory_firmware.py
@@ -1,116 +1,24 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python3
 
-import os
-import os.path
 import sys
-from collections import namedtuple
-
-Line = namedtuple('Line', ['size', 'offset', 'kind', 'data', 'checksum'])
+from intelhex import IntelHex
 
 USER_FIRMWARE = 'firmware/main.hex'
 BOOTLOADER_FIRMWARE = 'firmware/bootloader.hex'
 
-def parse_line(line):
-    """Parses an Intel HEX line into a Line tuple"""
-    if len(line) < 11:
-        exit("invalid Intel HEX line: %s" % line)
-    if line[0] != ':':
-        exit("invalid Intel HEX line: %s" % line)
-    line = line[1:]
-    try:
-        int(line, 16)
-    except ValueError:
-        exit("invalid Intel HEX line: %s" % line)
-    line = line.decode('hex')
-    return Line(line[0], line[1:3], line[3], line[4:-1], line[-1])
-
-def make_hex_line(line):
-    return ':' + ''.join(line).encode('hex')
-
-def make_hex(lines):
-    return '\n'.join(make_hex_line(l) for l in lines)
-
-
-def recompute_checksum(line):
-    checksum = chr((-(sum([ord(x) for x in ''.join(line)]) & 0xff)) & 0xff)
-    return Line(*(line[:-1] + (checksum,)))
-
-
-if not os.path.exists(USER_FIRMWARE):
+try:
+    user_hex = IntelHex(USER_FIRMWARE)
+except FileNotFoundError:
     exit("User firmware %s must be built" % USER_FIRMWARE)
-if not os.path.exists(BOOTLOADER_FIRMWARE):
+try:
+    boot_hex = IntelHex(BOOTLOADER_FIRMWARE)
+except FileNotFoundError:
     exit("Please copy %s to etc directory" % BOOTLOADER_FIRMWARE)
 
-with open(USER_FIRMWARE) as user_in:
-    user_hex = user_in.read()
-with open(BOOTLOADER_FIRMWARE) as boot_in:
-    boot_hex = boot_in.read()
-
-user_lines = user_hex.strip().split()
-if user_lines[-1] != ':00000001FF':
-    exit("Invalid user firmware")
-
-user_lines = user_lines[:-1]
-
-boot_lines = boot_hex.strip().split()
-if boot_lines[-1] != ':00000001FF':
-    exit("Invalid bootloader firmware")
-boot_lines = boot_lines[:-1]
-
-user_lines = [parse_line(l) for l in user_lines]
-boot_lines = [parse_line(l) for l in boot_lines]
-
-# if a 4-byte 0x0000 line is present in the user firmware, remove it, and make sure it points to the right place
-
-def replace_zero_vector(lines):
-    """Replace the zero vector with a jump to the bootloader, or append a new one"""
-    zero_lines = [(i, l) for i, l in enumerate(lines) if l.offset == '\0\0' and l.kind == '\0']
-    if not zero_lines:
-        lines.append(recompute_checksum(Line(
-            size='\x02',
-            offset='\x00\x00',
-            kind='\x00',
-            # point to the bootloader at 0x1C00
-            data='\xff\xcd',
-            checksum='\x00',
-        )))
-        return lines
-    index = zero_lines[0][0]
-    if len(zero_lines) > 1:
-        exit("Too many initial vector sections")
-    zero_line = zero_lines[0][1]
-    if ord(zero_line.size) < 2:
-        exit("Too small of an initial vector line: %d" % len(zero_line.size))
-    #if zero_line.data[:2] != '\x1b\xc0':
-    #    exit("Unexpected jump in the initial vector line (expected 0x13 0xc0)")
-    # replace it
-    zero_line = recompute_checksum(Line(
-        size=zero_line.size,
-        offset='\x00\x00',
-        kind=zero_line.kind,
-        # point to the bootloader at 0x1C00
-        data='\xff\xcd' + zero_line.data[2:],
-        checksum='\x00',
-    ))
-    lines[index] = zero_line
-    return lines
-
-def delete_all_vectors(lines):
-    """Delete the zero vector, if present"""
-    remove = set()
-    for i, l in enumerate(lines):
-        offset = (ord(l.offset[0]) << 8) + ord(l.offset[1])
-        if offset < 0x38:
-            remove.add(i)
-    return [l for i, l in enumerate(lines) if i not in remove]
-
-
-user_lines= replace_zero_vector(user_lines)
-boot_lines = delete_all_vectors(boot_lines)
-new_lines = [
-    # end record
-    Line(size='\0', offset='\0\0', kind='\x01', data='', checksum='\xFF'),
-]
-
-sys.stdout.write(make_hex(user_lines + boot_lines + new_lines))
-sys.stdout.write('\n')
+# Overwrite the reset vector to jump into the bootloader.
+# This is an RJMP instruction to byte address 0x1c00.
+user_hex[0:2] = [ 0xff, 0xcd ]
+# Merge hex files, preserving the application interrupt vectors
+user_hex.merge(boot_hex, overlap='ignore')
+# Omit start address for consistency with older versions of this tool
+user_hex.write_hex_file(sys.stdout, write_start_addr=False)


### PR DESCRIPTION
Fixes #24.

Use the intelhex library (from PyPI) to manipulate `.hex` files, instead
of using custom code. This substantially simplifies the tools. Note
that this library requires Python 3.

`make_factory_firmware.py` is confirmed to produce
identical results to the previous version, except for consolidating
contiguous regions that were written separately. (e.g., adjacent `.text`
and `.data` segments that were broken across multiple lines by
`avr-objcopy`)

Also, improve `hex_to_atmega.py` by writing only 8 values per
output line.

Signed-off-by: Taylor Yu <tlyu@mit.edu>